### PR TITLE
Implemented Permissions interface with broad Authorization layer

### DIFF
--- a/lib/Hub.ts
+++ b/lib/Hub.ts
@@ -11,6 +11,8 @@ import ActionsController from './controllers/ActionsController';
 import CollectionsController from './controllers/CollectionsController';
 import PermissionsController from './controllers/PermissionsController';
 import ProfileController from './controllers/ProfileController';
+import AuthorizationController from './controllers/AuthorizationController';
+import { Store } from './index';
 
 /**
  * Core class that handles Hub requests.
@@ -30,11 +32,12 @@ export default class Hub {
    * @param context Components for initializing the Hub.
    */
   public constructor(private context: Context) {
+    const authorization = Hub.getNewAuthorizationController(this.context.store);
     this._controllers = {
-      collections: new CollectionsController(this.context),
-      actions: new ActionsController(this.context),
-      permissions: new PermissionsController(this.context),
-      profile: new ProfileController(this.context),
+      collections: new CollectionsController(this.context, authorization),
+      actions: new ActionsController(this.context, authorization),
+      permissions: new PermissionsController(this.context, authorization),
+      profile: new ProfileController(this.context, authorization),
     };
 
     this._authentication = new Authentication({
@@ -42,7 +45,11 @@ export default class Hub {
       keys: this.context.keys,
       cryptoSuites: this.context.cryptoSuites,
     });
+  }
 
+  // Used for unit test overrides
+  private static getNewAuthorizationController(store: Store): AuthorizationController {
+    return new AuthorizationController(store);
   }
 
   /**

--- a/lib/controllers/AuthorizationController.ts
+++ b/lib/controllers/AuthorizationController.ts
@@ -1,0 +1,64 @@
+import HubRequest from '../models/HubRequest';
+import { Store } from '../index';
+import PermissionGrant, { PERMISSION_GRANT_SCHEMA } from '../models/PermissionGrant';
+import HubError from '../models/HubError';
+
+/**
+ * Internal controller for authorizing requests to an Identity Hub
+ */
+export default class AuthorizationController {
+
+  /** Creates an AuthorizationController using the given Store */
+  constructor (private store: Store) {
+  }
+
+  /**
+   * Checks if a request is authorized
+   * @param request HubRequest needing authorization
+   * @returns true is authorized, else false
+   */
+  async authorize(request: HubRequest): Promise<Boolean> {
+    // if the request is to their own hub, always allow
+    if (request.iss === request.aud) {
+      return true;
+    }
+    const requester = request.iss;
+    const schema = request.request ? request.request.schema : undefined;
+    let operation: RegExp;
+    switch (request.getAction().toLowerCase()) {
+      case 'create':
+        operation = /C/;
+        break;
+      case 'read':
+        operation = /R/;
+        break;
+      case 'update':
+        operation = /U/;
+        break;
+      case 'delete':
+        operation = /D/;
+        break;
+      case 'execute':
+        operation = /X/;
+        break;
+      default:
+        throw new HubError('unknown operation', 400);
+    }
+    const permissions = await this.store.queryDocuments({
+      owner: request.aud,
+      schema: PERMISSION_GRANT_SCHEMA,
+    });
+    let permissionFound = false;
+    permissions.forEach((permission) => {
+      const grant = permission.payload as PermissionGrant;
+      if (grant.grantee !== requester ||
+         (schema && grant.object_type !== schema) ||
+          !operation.test(grant.allow)) {
+        return;
+      }
+      // we found a permission
+      permissionFound = true;
+    });
+    return permissionFound;
+  }
+}

--- a/lib/controllers/AuthorizationController.ts
+++ b/lib/controllers/AuthorizationController.ts
@@ -58,7 +58,7 @@ export default class AuthorizationController {
     permissions.forEach((permission) => {
       const grant = permission.payload as PermissionGrant;
       if (grant.grantee !== requester ||
-         (schema && grant.object_type !== schema) ||
+         (grant.object_type !== schema) ||
           !operation.test(grant.allow)) {
         return;
       }

--- a/lib/controllers/AuthorizationController.ts
+++ b/lib/controllers/AuthorizationController.ts
@@ -23,7 +23,13 @@ export default class AuthorizationController {
       return true;
     }
     const requester = request.iss;
-    const schema = request.request ? request.request.schema : undefined;
+    if (!request.request) {
+      throw new HubError('request required');
+    }
+    const schema = request.request.schema;
+    if (!schema) {
+      throw new HubError('request.schema required');
+    }
     let operation: RegExp;
     switch (request.getAction().toLowerCase()) {
       case 'create':

--- a/lib/controllers/BaseController.ts
+++ b/lib/controllers/BaseController.ts
@@ -3,6 +3,7 @@ import Context from '../interfaces/Context';
 import HubError from '../models/HubError';
 import HubRequest from '../models/HubRequest';
 import HubResponse from '../models/HubResponse';
+import AuthorizationController from './AuthorizationController';
 
 /**
  * Abstract controller class for every interface controllers to inherit.
@@ -36,7 +37,7 @@ export default abstract class BaseController {
    *
    * @param context The context object containing all the injected components.
    */
-  constructor(protected context: Context) { }
+  constructor(protected context: Context, private authorization: AuthorizationController) { }
 
   /**
    * Handles the Hub request.
@@ -47,6 +48,10 @@ export default abstract class BaseController {
 
     if (!handler) {
       return HubResponse.withError(new HubError(`Handling of '${action}' action is not supported.`, HttpStatus.BAD_REQUEST));
+    }
+
+    if (!await this.authorization.authorize(request)) {
+      return HubResponse.withError(new HubError('Unauthorized request.', HttpStatus.FORBIDDEN));
     }
 
     return await handler.call(this, request);

--- a/lib/controllers/PermissionsController.ts
+++ b/lib/controllers/PermissionsController.ts
@@ -3,13 +3,23 @@ import BaseController from './BaseController';
 import HubError from '../models/HubError';
 import HubRequest from '../models/HubRequest';
 import HubResponse from '../models/HubResponse';
+import PermissionGrant, { PERMISSION_GRANT_SCHEMA } from '../models/PermissionGrant';
 
 /**
  * This class handles all the permission requests.
  */
 export default class PermissionsController extends BaseController {
   async handleCreateRequest(request: HubRequest): Promise<HubResponse> {
-    throw new HubError(`${request.getAction()} handler not implemented.`, HttpStatus.NOT_IMPLEMENTED);
+    PermissionsController.validateSchema(request);
+    const permission = PermissionsController.getPermissionGrant(request);
+
+    const result = await this.context.store.createDocument({
+      owner: request.aud,
+      schema: PERMISSION_GRANT_SCHEMA,
+      payload: permission,
+    });
+
+    return HubResponse.withObject(result);
   }
 
   async handleExecuteRequest(request: HubRequest): Promise<HubResponse> {
@@ -17,14 +27,84 @@ export default class PermissionsController extends BaseController {
   }
 
   async handleReadRequest(request: HubRequest): Promise<HubResponse> {
-    throw new HubError(`${request.getAction()} handler not implemented.`, HttpStatus.NOT_IMPLEMENTED);
+    PermissionsController.validateSchema(request);
+
+    const results = await this.context.store.queryDocuments({
+      owner: request.aud,
+      schema: PERMISSION_GRANT_SCHEMA,
+    });
+
+    if (request.request && request.request.id) {
+      const id = request.request.id;
+      const match = results.filter(result => result.id === id);
+      if (match.length > 0) {
+        return HubResponse.withObject(match[0]);
+      }
+      return HubResponse.withError(new HubError('Permission not found', 404));
+    }
+    return HubResponse.withObjects(results);
   }
 
   async handleDeleteRequest(request: HubRequest): Promise<HubResponse> {
-    throw new HubError(`${request.getAction()} handler not implemented.`, HttpStatus.NOT_IMPLEMENTED);
+    PermissionsController.validateSchema(request);
+
+    if (!request.request || !request.request.id) {
+      throw new HubError('request.id is required', 400);
+    }
+
+    const id = request.request.id;
+
+    await this.context.store.deleteDocument({
+      id,
+      owner: request.aud,
+      schema: PERMISSION_GRANT_SCHEMA,
+    });
+
+    return HubResponse.withSuccess();
   }
 
   async handleUpdateRequest(request: HubRequest): Promise<HubResponse> {
-    throw new HubError(`${request.getAction()} handler not implemented.`, HttpStatus.NOT_IMPLEMENTED);
+    PermissionsController.validateSchema(request);
+    const permission = PermissionsController.getPermissionGrant(request);
+    if (!request.request || !request.request.id) {
+      throw new HubError('request.id is required', 400);
+    }
+
+    const id = request.request.id;
+
+    const result = await this.context.store.updateDocument({
+      id,
+      owner: request.aud,
+      schema: PERMISSION_GRANT_SCHEMA,
+      payload: permission,
+    });
+
+    return HubResponse.withObject(result);
+  }
+
+  // given a hub request, attempts to retrieve the PermissionGrant from it's payload
+  private static getPermissionGrant(request: HubRequest): PermissionGrant {
+    if (!request.payload) {
+      throw new HubError('request.payload required', 400);
+    }
+    const permission = request.payload.data as PermissionGrant;
+    if (!permission.owner ||
+        !permission.grantee ||
+        !permission.allow ||
+        !permission.object_type ||
+        !permission.created_by) {
+      throw new HubError('request.payload.data must be a PermissionGrant.', 400);
+    }
+    return permission;
+  }
+
+  // given a hub request, validates the request contains the permission grant schema
+  private static validateSchema(request: HubRequest) {
+    if (!request.request || !request.request.schema) {
+      throw new HubError('request.schema required', 400);
+    }
+    if (request.request.schema !== PERMISSION_GRANT_SCHEMA) {
+      throw new HubError(`request.schema must be ${PERMISSION_GRANT_SCHEMA}`, 400);
+    }
   }
 }

--- a/lib/models/HubRequest.ts
+++ b/lib/models/HubRequest.ts
@@ -79,7 +79,7 @@ export default class HubRequest {
     this['@type'] = body['@type'];
 
     // Throw error if 'add' or 'update' request does not contain a payload with data.
-    if (['add', 'update'].includes(this._action)) {
+    if (['create', 'update'].includes(this._action)) {
       if (!body.payload || !body.payload.data) {
         throw new HubError('Add/Update requests must specify the "payload.data" field.', HttpStatus.BAD_REQUEST);
       }

--- a/lib/models/PermissionGrant.ts
+++ b/lib/models/PermissionGrant.ts
@@ -1,0 +1,13 @@
+
+export const PERMISSION_GRANT_SCHEMA = 'schema.identity.foundation/0.1/PermissionGrant';
+
+/**
+ * Represents a Permission Grant object
+ */
+export default interface PermissionGrant {
+  owner: string;
+  grantee: string;
+  allow: string;
+  object_type: string;
+  created_by: string;
+}

--- a/tests/controllers/AuthorizationController.spec.ts
+++ b/tests/controllers/AuthorizationController.spec.ts
@@ -38,7 +38,23 @@ describe('AuthorizationController', () => {
       });
       store.and.returnValues([]);
       expect(await auth.authorize(request)).toBeFalsy();
+      expect(store).toHaveBeenCalled();
     });
+
+    function createPermissionGrant(owner: string, grantee: string, schema: string, allow: string): StoredObject {
+      return {
+        owner,
+        schema: PERMISSION_GRANT_SCHEMA,
+        id: Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),
+        payload: {
+          owner,
+          grantee,
+          allow,
+          object_type: schema,
+          created_by: '*',
+        } as PermissionGrant,
+      };
+    }
 
     async function checkPermissionFor(operation: string, allowString: string) {
       const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
@@ -57,19 +73,7 @@ describe('AuthorizationController', () => {
           },
         },
       });
-      const permission: StoredObject = {
-        owner,
-        schema: PERMISSION_GRANT_SCHEMA,
-        id: Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),
-        payload: {
-          owner,
-          grantee: sender,
-          allow: allowString,
-          object_type: schema,
-          created_by: '*',
-        } as PermissionGrant,
-      };
-      store.and.returnValues([permission]);
+      store.and.returnValues([createPermissionGrant(owner, sender, schema, allowString)]);
       expect(await auth.authorize(request)).toBeTruthy();
     }
 
@@ -88,5 +92,126 @@ describe('AuthorizationController', () => {
     it('should accept for execute requests', async () => {
       await checkPermissionFor('execute', '----X');
     });
+
+    it('should require the request field', async () => {
+      const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const sender = `${owner}-not`;
+
+      const request = new HubRequest({
+        iss: sender,
+        aud: owner,
+        '@type': 'unknown/create',
+        payload: {
+          data: {
+            // nothing needs to be here
+          },
+        },
+      });
+
+      try {
+        await auth.authorize(request);
+        fail('Did not require request field');
+      } catch (err) {
+        expect(err.message).toContain('request');
+      }
+    });
+
+    it('should require the schema field', async () => {
+      const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const sender = `${owner}-not`;
+
+      const request = new HubRequest({
+        iss: sender,
+        aud: owner,
+        '@type': 'unknown/create',
+        request: {
+        },
+        payload: {
+          data: {
+            // nothing needs to be here
+          },
+        },
+      });
+
+      try {
+        await auth.authorize(request);
+        fail('Did not require schema field');
+      } catch (err) {
+        expect(err.message).toContain('schema');
+      }
+    });
+
+    it('should ignore other permission grants by grantee', async() => {
+      const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const sender = `${owner}-not`;
+      const grantee = `${owner}-grantee`;
+      const schema = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
+      const request = new HubRequest({
+        iss: sender,
+        aud: owner,
+        '@type': 'unknown/create',
+        request: {
+          schema,
+        },
+      });
+      store.and.returnValues([createPermissionGrant(owner, grantee, schema, 'C----')]);
+      expect(await auth.authorize(request)).toBeFalsy();
+      expect(store).toHaveBeenCalled();
+    });
+
+    it('should ignore other permission grants by schema', async() => {
+      const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const sender = `${owner}-not`;
+      const schema = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
+      const permissionSchema = `${schema}-not`;
+      const request = new HubRequest({
+        iss: sender,
+        aud: owner,
+        '@type': 'unknown/create',
+        request: {
+          schema,
+        },
+      });
+      store.and.returnValues([createPermissionGrant(owner, sender, permissionSchema, 'C----')]);
+      expect(await auth.authorize(request)).toBeFalsy();
+      expect(store).toHaveBeenCalled();
+    });
+
+    it('should ignore other permission grants by operation', async() => {
+      const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const sender = `${owner}-not`;
+      const schema = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
+      const request = new HubRequest({
+        iss: sender,
+        aud: owner,
+        '@type': 'unknown/create',
+        request: {
+          schema,
+        },
+      });
+      store.and.returnValues([createPermissionGrant(owner, sender, schema, '-R---')]);
+      expect(await auth.authorize(request)).toBeFalsy();
+      expect(store).toHaveBeenCalled();
+    });
+
+    it('should fail if the operation could not be identified', async() => {
+      const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const sender = `${owner}-not`;
+      const schema = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
+      const request = new HubRequest({
+        iss: sender,
+        aud: owner,
+        '@type': 'unknown/unknown',
+        request: {
+          schema,
+        },
+      });
+      try {
+        await auth.authorize(request);
+        fail('Did not fail for unknown operation');
+      } catch (err) {
+        expect(err.message).toContain('operation');
+      }
+    })
   });
 });

--- a/tests/controllers/AuthorizationController.spec.ts
+++ b/tests/controllers/AuthorizationController.spec.ts
@@ -1,0 +1,92 @@
+import TestStore from '../mocks/TestStore';
+import AuthorizationController from '../../lib/controllers/AuthorizationController';
+import HubRequest from '../../lib/models/HubRequest';
+import { StoredObject } from '../../lib/interfaces/Store';
+import PermissionGrant, { PERMISSION_GRANT_SCHEMA } from '../../lib/models/PermissionGrant';
+
+describe('AuthorizationController', () => {
+  let store: jasmine.Spy;
+  let auth: AuthorizationController;
+
+  beforeEach(() => {
+    const testStore = new TestStore();
+    store = spyOn(testStore, 'queryDocuments')
+    auth = new AuthorizationController(testStore);
+  });
+
+  describe('authorize', () => {
+    it('should allow did owner without rules', async () => {
+      const did = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const request = new HubRequest({
+        iss: did,
+        aud: did,
+        '@type': 'unknown/action',
+      });
+      expect(await auth.authorize(request)).toBeTruthy();
+    });
+
+    it('should reject non-owner without rules', async () => {
+      const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const sender = `${owner}-not`;
+      const request = new HubRequest({
+        iss: sender,
+        aud: owner,
+        '@type': 'unknown/create',
+        request: {
+          schema: 'will not matter here',
+        },
+      });
+      store.and.returnValues([]);
+      expect(await auth.authorize(request)).toBeFalsy();
+    });
+
+    async function checkPermissionFor(operation: string, allowString: string) {
+      const owner = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+      const sender = `${owner}-not`;
+      const schema = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
+      const request = new HubRequest({
+        iss: sender,
+        aud: owner,
+        '@type': `unknown/${operation}`,
+        request: {
+          schema,
+        },
+        payload: {
+          data: {
+            // nothing needs to be here
+          },
+        },
+      });
+      const permission: StoredObject = {
+        owner,
+        schema: PERMISSION_GRANT_SCHEMA,
+        id: Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),
+        payload: {
+          owner,
+          grantee: sender,
+          allow: allowString,
+          object_type: schema,
+          created_by: '*',
+        } as PermissionGrant,
+      };
+      store.and.returnValues([permission]);
+      expect(await auth.authorize(request)).toBeTruthy();
+    }
+
+    it('should accept for create requests', async () => {
+      await checkPermissionFor('create', 'C----');
+    });
+    it('should accept for read requests', async () => {
+      await checkPermissionFor('read', '-R---');
+    });
+    it('should accept for update requests', async () => {
+      await checkPermissionFor('update', '--U--');
+    });
+    it('should accept for delete requests', async () => {
+      await checkPermissionFor('delete', '---D-');
+    });
+    it('should accept for execute requests', async () => {
+      await checkPermissionFor('execute', '----X');
+    });
+  });
+});

--- a/tests/controllers/AuthorizationController.spec.ts
+++ b/tests/controllers/AuthorizationController.spec.ts
@@ -31,7 +31,7 @@ describe('AuthorizationController', () => {
       const request = new HubRequest({
         iss: sender,
         aud: owner,
-        '@type': 'unknown/create',
+        '@type': 'unknown/read',
         request: {
           schema: 'will not matter here',
         },
@@ -149,12 +149,12 @@ describe('AuthorizationController', () => {
       const request = new HubRequest({
         iss: sender,
         aud: owner,
-        '@type': 'unknown/create',
+        '@type': 'unknown/read',
         request: {
           schema,
         },
       });
-      store.and.returnValues([createPermissionGrant(owner, grantee, schema, 'C----')]);
+      store.and.returnValues([createPermissionGrant(owner, grantee, schema, '-R---')]);
       expect(await auth.authorize(request)).toBeFalsy();
       expect(store).toHaveBeenCalled();
     });
@@ -167,12 +167,12 @@ describe('AuthorizationController', () => {
       const request = new HubRequest({
         iss: sender,
         aud: owner,
-        '@type': 'unknown/create',
+        '@type': 'unknown/read',
         request: {
           schema,
         },
       });
-      store.and.returnValues([createPermissionGrant(owner, sender, permissionSchema, 'C----')]);
+      store.and.returnValues([createPermissionGrant(owner, sender, permissionSchema, '-R---')]);
       expect(await auth.authorize(request)).toBeFalsy();
       expect(store).toHaveBeenCalled();
     });
@@ -187,6 +187,11 @@ describe('AuthorizationController', () => {
         '@type': 'unknown/create',
         request: {
           schema,
+        },
+        payload: {
+          data: {
+            // nothing needs to be here
+          },
         },
       });
       store.and.returnValues([createPermissionGrant(owner, sender, schema, '-R---')]);

--- a/tests/controllers/PermissionsController.spec.ts
+++ b/tests/controllers/PermissionsController.spec.ts
@@ -1,0 +1,254 @@
+import PermissionsController from '../../lib/controllers/PermissionsController';
+import TestContext from '../mocks/TestContext';
+import TestAuthorization from '../mocks/TestAuthorization';
+import TestStore from '../mocks/TestStore';
+import HubRequest from '../../lib/models/HubRequest';
+import { PERMISSION_GRANT_SCHEMA } from '../../lib/models/PermissionGrant';
+
+describe('PermissionsController', () => {
+  let permissionsController: PermissionsController;
+  let store: TestStore;
+
+  beforeEach(() => {
+    const context = new TestContext();
+    const authorization = new TestAuthorization();
+    permissionsController = new PermissionsController(context, authorization);
+    store = context.store;
+  });
+
+  describe('validateSchema', () => {
+    it('should require a schema', async () => {
+      const request = makeRequest({}, {});
+      try {
+        await permissionsController.handleCreateRequest(request);
+        fail('should have thrown');
+      } catch (err) {
+        expect(err.message).toContain('schema');
+      }
+    });
+
+    it('should require the PermissionGrant schema', async () => {
+      const request = makeRequest({}, { schema: 'test' });
+      try {
+        await permissionsController.handleCreateRequest(request);
+        fail('should have thrown');
+      } catch (err) {
+        expect(err.message).toContain(PERMISSION_GRANT_SCHEMA);
+      }
+    });
+  });
+
+  describe('getPermissionGrant', () => {
+    it('should require a payload', async () => {
+      const request = makeRequest(undefined);
+      try {
+        await permissionsController.handleCreateRequest(request);
+        fail('should have thrown');
+      } catch (err) {
+        expect(err.message).toContain('payload');
+      }
+    });
+
+    it('should validate the data', async () => {
+      const request = makeRequest({});
+      try {
+        await permissionsController.handleCreateRequest(request);
+        fail('should have thrown');
+      } catch (err) {
+        expect(err.message).toContain('PermissionGrant');
+      }
+    });
+
+    it('should return the contained data', async() => {
+      const permission = makePermission();
+      const request = makeRequest(permission);
+      spyOn(store, 'createDocument').and.callFake((document: any) => document);
+      const result = await permissionsController.handleCreateRequest(request);
+      const response: any = result.getResponseBody().payload[0].data;
+      expect(response).toEqual(permission);
+    });
+  });
+
+  describe('handleCreateRequest', () => {
+    it('should return the stored data', async() => {
+      const permission = makePermission();
+      const request = makeRequest(permission);
+      spyOn(store, 'createDocument').and.callFake((document: any) => document);
+      const result = await permissionsController.handleCreateRequest(request);
+      const response: any = result.getResponseBody().payload[0].data;
+      expect(response).toEqual(permission);
+    });
+
+    it('should validate the schema', async() => {
+      checkValidateSchemaIsCalled(async (request) => {await permissionsController.handleCreateRequest(request)});
+    });
+
+    it('should validate the payload', async () => {
+      checkGetPermissionGrantIsCalled(async (request) => {await permissionsController.handleCreateRequest(request)})
+    });
+  });
+
+  describe('handleExecuteRequest', () => {
+    it('should throw', async () => {
+      const request = makeRequest(undefined);
+      try {
+        await permissionsController.handleExecuteRequest(request);
+        fail('did not throw');
+      } catch (err) {
+        expect(err.message).toContain('implemented');
+      }
+    })
+  });
+
+  describe('handleReadRequest', () => {
+    it('should validate the schema', async() => {
+      checkValidateSchemaIsCalled(async (request) => {await permissionsController.handleReadRequest(request)});
+    });
+
+    it('should return the contained data', async() => {
+      const permission = makePermission();
+      const request = makeRequest(undefined);
+      spyOn(store, 'queryDocuments').and.callFake((_: any) => {
+        return [{
+          owner: request.aud,
+          id: Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),
+          schema: PERMISSION_GRANT_SCHEMA,
+          payload: permission,
+        }];
+      });
+      const result = await permissionsController.handleReadRequest(request);
+      const response: any = result.getResponseBody().payload[0].data;
+      expect(response).toEqual(permission);
+    });
+
+    it('should return nothing when an id filter is included', async () => {
+      const permission = makePermission();
+      const id = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
+      const request = makeRequest(undefined, {id, schema: PERMISSION_GRANT_SCHEMA});
+      spyOn(store, 'queryDocuments').and.callFake((_: any) => {
+        return [{
+          owner: request.aud,
+          id: `${id}-not`,
+          schema: PERMISSION_GRANT_SCHEMA,
+          payload: permission,
+        }];
+      });
+      const result = await permissionsController.handleReadRequest(request);
+      const response: any = result.getResponseBody();
+      expect(response.error).toBeDefined();
+    });
+
+    it('should return only if id matches', async () => {
+      const permission = makePermission();
+      const id = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
+      const request = makeRequest(undefined, {id, schema: PERMISSION_GRANT_SCHEMA});
+      spyOn(store, 'queryDocuments').and.callFake((_: any) => {
+        return [{
+          owner: request.aud,
+          id: `${id}`,
+          schema: PERMISSION_GRANT_SCHEMA,
+          payload: permission,
+        },
+        {
+          owner: request.aud,
+          id: `${id}-not`,
+          schema: PERMISSION_GRANT_SCHEMA,
+          payload: {},
+        }];
+      });
+      const result = await permissionsController.handleReadRequest(request);
+      const response: any = result.getResponseBody().payload[0].data;
+      expect(response).toEqual(permission);
+    });
+  });
+
+  describe('handleCreateRequest', () => {
+    it('should return the stored data', async() => {
+      const permission = makePermission();
+      const request = makeRequest(permission);
+      spyOn(store, 'createDocument').and.callFake((document: any) => document);
+      const result = await permissionsController.handleCreateRequest(request);
+      const response: any = result.getResponseBody().payload[0].data;
+      expect(response).toEqual(permission);
+    });
+
+    it('should validate the schema', async() => {
+      checkValidateSchemaIsCalled(async (request) => {await permissionsController.handleCreateRequest(request)});
+    });
+
+    it('should validate the payload', async () => {
+      checkGetPermissionGrantIsCalled(async (request) => {await permissionsController.handleCreateRequest(request)})
+    });
+  });
+
+  describe('handleCreateRequest', () => {
+    it('should return the stored data', async() => {
+      const permission = makePermission();
+      const request = makeRequest(permission);
+      spyOn(store, 'createDocument').and.callFake((document: any) => document);
+      const result = await permissionsController.handleCreateRequest(request);
+      const response: any = result.getResponseBody().payload[0].data;
+      expect(response).toEqual(permission);
+    });
+
+    it('should validate the schema', async() => {
+      checkValidateSchemaIsCalled(async (request) => {await permissionsController.handleCreateRequest(request)});
+    });
+
+    it('should validate the payload', async () => {
+      checkGetPermissionGrantIsCalled(async (request) => {await permissionsController.handleCreateRequest(request)})
+    });
+  });
+
+  async function checkGetPermissionGrantIsCalled(call: (request: HubRequest) => any) {
+    const spy = spyOn(PermissionsController, 'getPermissionGrant' as 'prototype').and.throwError('');
+    const request = makeRequest({});
+    try {
+      await call(request);
+    } catch (err) {
+      expect(spy).toHaveBeenCalled();
+    }
+  }
+
+  async function checkValidateSchemaIsCalled(call: (request: HubRequest) => any) {
+    const spy = spyOn(PermissionsController, 'validateSchema' as 'prototype').and.throwError('');
+    const request = makeRequest(makePermission());
+    await call(request);
+    try {
+      await call(request);
+    } catch (err) {
+      expect(spy).toHaveBeenCalled();
+    }
+  }
+
+  function makePermission() {
+    return {
+      owner: Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),
+      grantee: Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),
+      allow: '-----',
+      object_type: Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16),
+      created_by: '*',
+    }
+  }
+
+  function makeRequest(permission: any, request: any = { schema: PERMISSION_GRANT_SCHEMA }): HubRequest {
+    const did = `did:test:${Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16)}`;
+    if (permission) {
+      return new HubRequest({
+        request,
+        iss: did,
+        aud: did,
+        '@type': 'Permissions/Action',
+        payload: {
+          data: permission,
+        }
+      });
+    }
+    return new HubRequest({
+      request,
+      iss: did,
+      aud: did,
+      '@type': 'Permissions/Action'
+    });
+  }
+})

--- a/tests/controllers/ProfileController.spec.ts
+++ b/tests/controllers/ProfileController.spec.ts
@@ -4,11 +4,13 @@ import HubResponse from '../../lib/models/HubResponse';
 import ProfileController, { PROFILE_SCHEMA } from '../../lib/controllers/ProfileController';
 import TestContext from '../mocks/TestContext';
 import HubError from '../../lib/models/HubError';
+import TestAuthorization from '../mocks/TestAuthorization';
 
 const did = 'did:test:alice.id';
 
 describe('ProfileController', () => {
   let testContext: TestContext;
+  let testAuthorization: TestAuthorization;
   let storeCreate: jasmine.Spy;
   let storeQuery: jasmine.Spy;
   let storeUpdate: jasmine.Spy;
@@ -18,6 +20,7 @@ describe('ProfileController', () => {
   let request: HubRequest;
   beforeEach(() => {
     testContext = new TestContext();
+    testAuthorization = new TestAuthorization();
     storeCreate = spyOn(testContext.store, 'createDocument');
     storeQuery = spyOn(testContext.store, 'queryDocuments');
     storeUpdate = spyOn(testContext.store, 'updateDocument');
@@ -26,7 +29,7 @@ describe('ProfileController', () => {
     spyOn(HubResponse, 'withObject').and.callFake((obj: any) => obj);
     spyOn(HubResponse, 'withObjects').and.callFake((obj: any) => obj);
     spyOn(HubResponse, 'withError').and.callFake((obj: any) => obj);
-    controller = new ProfileController(testContext);
+    controller = new ProfileController(testContext, testAuthorization);
     request = new HubRequest({
       iss: did,
       aud: did,

--- a/tests/mocks/TestAuthorization.ts
+++ b/tests/mocks/TestAuthorization.ts
@@ -1,0 +1,23 @@
+import AuthorizationController from "../../lib/controllers/AuthorizationController";
+import HubRequest from "../../lib/models/HubRequest";
+import TestStore from "./TestStore";
+
+export default class TestAuthorization extends AuthorizationController {
+
+  constructor() {
+    super(new TestStore());
+  }
+
+  private value: boolean | undefined;
+
+  async authorize(_: HubRequest): Promise<Boolean> {
+    if (!this.value) {
+      throw new Error('TestAuthorization must have authorize set.');
+    }
+    return this.value;
+  }
+
+  setAuthorize(toReturn: boolean) {
+    this.value = toReturn;
+  }
+}

--- a/tests/mocks/TestController.ts
+++ b/tests/mocks/TestController.ts
@@ -2,6 +2,7 @@ import BaseController from '../../lib/controllers/BaseController';
 import HubRequest from '../../lib/models/HubRequest';
 import HubResponse from '../../lib/models/HubResponse';
 import TestContext from './TestContext';
+import TestAuthorization from './TestAuthorization';
 
 /**
  * TestController implements an Interface controller (Action, Collection, Profile, etc.) with dynamic
@@ -16,7 +17,9 @@ export default class TestController extends BaseController {
   private onExecute?: (request: HubRequest) => Promise<HubResponse>;
 
   constructor() {
-    super(TestContext.instance);
+    const author = new TestAuthorization();
+    author.setAuthorize(true);
+    super(TestContext.instance, author);
   }
 
   async handleCreateRequest(request: HubRequest): Promise<HubResponse> {

--- a/tests/models/HubRequest.spec.ts
+++ b/tests/models/HubRequest.spec.ts
@@ -112,7 +112,7 @@ describe('HubRequest', () => {
     }
 
     it('should require payloads for add requests', (done) => {
-      payloadIsRequiredFor('Add', done);
+      payloadIsRequiredFor('Create', done);
     });
 
     it('should require payloads for update requests', (done) => {


### PR DESCRIPTION
* Added a permissions interface that accepts PermissionGrant objects specified in https://hackmd.io/j_hVcMyNRAmDrTN2E9gUIw (Without the ability to filter*)
* Added an authorization spec that follows the same document's logic for permission grants
* Fixed HubRequests to check given the correct action types

Any reformatting of the request and responses is out of scope for this PR (including permission filters)